### PR TITLE
Màj ExtraCat 61

### DIFF
--- a/last_compilation.json
+++ b/last_compilation.json
@@ -1,1 +1,1 @@
-{"last_compilations": [{"ExtraCat": 56}]}
+{"last_compilations": [{"ExtraCat": 61}]}


### PR DESCRIPTION
Mettre à jour le fichier JSON pour indiquer qu'il existe une version 61 (actuellement plusieurs utilisateurs sont sur la 56, qui est buguée pour les fichiers de NNA/NNB en entrée). Avec cette édition du fichier, un bouton proposant la mise à jour apparaîtra sur les formulaires Extracat à la prochaine ouverture.